### PR TITLE
Feature/#24

### DIFF
--- a/src/main/java/com/luppy/parkingppak/controller/AccountController.java
+++ b/src/main/java/com/luppy/parkingppak/controller/AccountController.java
@@ -3,10 +3,7 @@ package com.luppy.parkingppak.controller;
 import com.luppy.parkingppak.domain.Account;
 import com.luppy.parkingppak.domain.AccountRepository;
 import com.luppy.parkingppak.domain.Card;
-import com.luppy.parkingppak.domain.dto.AccountDto;
-import com.luppy.parkingppak.domain.dto.LoginRequestDto;
-import com.luppy.parkingppak.domain.dto.LoginResponseDto;
-import com.luppy.parkingppak.domain.dto.Response;
+import com.luppy.parkingppak.domain.dto.*;
 import com.luppy.parkingppak.domain.enumclass.NaviType;
 import com.luppy.parkingppak.domain.enumclass.OilType;
 import com.luppy.parkingppak.service.AccountService;
@@ -80,11 +77,12 @@ public class AccountController {
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "카드등록 성공.")
     })
-    @PutMapping("/accounts/card-type/{cardType}")
-    public ResponseEntity<?> registerCard(@RequestHeader("Authorization") String jwt, @PathVariable String cardType) {
+    @PutMapping("/accounts/card-type")
+    public ResponseEntity<?> registerCard(@RequestHeader("Authorization") String jwt, @RequestBody CardDto cardDto) {
 
-        Optional<Card> registeredCard = accountService.registerCard(jwt, cardType);
+        CardDto registeredCard = accountService.registerCard(jwt, cardDto);
 
+        if(registeredCard == null) return ResponseEntity.badRequest().body("계정을 찾지못하여 카드가 등록되지 않았습니다.");
         return ResponseEntity.ok().body(registeredCard);
     }
 

--- a/src/main/java/com/luppy/parkingppak/controller/FavoriteListController.java
+++ b/src/main/java/com/luppy/parkingppak/controller/FavoriteListController.java
@@ -14,10 +14,10 @@ import java.util.List;
 @RequiredArgsConstructor
 public class FavoriteListController {
 
-    private AccountRepository accountRepository;
-    private ParkingLogRepository parkingLogRepository;
-    private GasStationRepository gasStationRepository;
-    private JwtUtil jwtUtil;
+    private final AccountRepository accountRepository;
+    private final ParkingLogRepository parkingLogRepository;
+    private final GasStationRepository gasStationRepository;
+    private final JwtUtil jwtUtil;
 
     @PostMapping("/")
     public ResponseEntity<?> addFavorite(@RequestHeader("Authorization") String jwt, @RequestBody FavoriteRequestDto dto){
@@ -79,12 +79,14 @@ public class FavoriteListController {
 
         if(account!=null){
             if(dto.getType().equals("gas-station")){
-                GasStation gasStation = gasStationRepository.findById(dto.getDataId()).get();
+                GasStation gasStation = gasStationRepository.findById(dto.getDataId()).orElse(null);
+                if(gasStation == null) return ResponseEntity.badRequest().body("잘못된 주유소 id 입니다.");
                 account.getGasStationList().remove(gasStation);
                 accountRepository.save(account);
                 return ResponseEntity.ok().body("정상적으로 삭제되었습니다.");
             }else if(dto.getType().equals("parking-lot")) {
-                ParkingLot parkingLot = parkingLogRepository.findById(dto.getDataId()).get();
+                ParkingLot parkingLot = parkingLogRepository.findById(dto.getDataId()).orElse(null);
+                if(parkingLot == null) return ResponseEntity.badRequest().body("잘못된 주차장 id 입니다.");
                 account.getParkingLotList().remove(parkingLot);
                 accountRepository.save(account);
                 return ResponseEntity.ok().body("정상적으로 삭제되었습니다.");

--- a/src/main/java/com/luppy/parkingppak/domain/CardRepository.java
+++ b/src/main/java/com/luppy/parkingppak/domain/CardRepository.java
@@ -7,6 +7,6 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface CardRepository extends JpaRepository<Card, Long> {
 
-    //카드 종류가 정해지면, card 이름으로 등록될 수 있도록 수정.
     Card findByCompName(CardCompName compName);
+    Card findByName(String cardName);
 }

--- a/src/main/java/com/luppy/parkingppak/domain/dto/CardDto.java
+++ b/src/main/java/com/luppy/parkingppak/domain/dto/CardDto.java
@@ -1,0 +1,18 @@
+package com.luppy.parkingppak.domain.dto;
+
+import com.luppy.parkingppak.domain.enumclass.CardCompName;
+import lombok.Builder;
+import lombok.Data;
+
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+
+@Builder
+@Data
+public class CardDto {
+
+    private Long id;
+    private String name;
+    private CardCompName compName;
+    private String content;
+}

--- a/src/main/java/com/luppy/parkingppak/service/AccountService.java
+++ b/src/main/java/com/luppy/parkingppak/service/AccountService.java
@@ -117,9 +117,6 @@ public class AccountService {
 
         Optional<Account> account = accountRepository.findById(Long.valueOf(jwtUtil.getAccountId(jwtToken)));
 
-        System.out.println(account);
-        System.out.println(naviType);
-
         if(account.isEmpty()) return Optional.empty();
         else return account
                 .map(it -> {


### PR DESCRIPTION
- 카드정보 등록 API 로직 수정
    - 기존 :  경로 파라미터로 받은 타입 값으로 카드 테이블 조회하여 등록.
    - 변경 : body로 등록할 카드 정보를 받아 카드 db에 있을 시 매핑, 없을 시 추가하여 계정과 매핑.

- 찜 목록 제거 API 로직 수정
    - 요청받은 데이터(주차장, 주유소) id로 데이터 조회 시 없을 경우 에러 문구 반환로직 추가.
    - 로직이 controller에 모두 구현되어있는데 추후에 layer를 나누도록 하겠슴다 ㅎㅎ

테스트는 다 해봤고 잘 동작하고, goorm ide에 반영하기 위해 우선 merge 하겠습니다!